### PR TITLE
Support for writing out the Metadata table

### DIFF
--- a/llvm/include/llvm/BinaryFormat/SQELF.h
+++ b/llvm/include/llvm/BinaryFormat/SQELF.h
@@ -16,14 +16,16 @@ public:
   } Metadata;
 
 public:
-  SQELF(const Metadata &M);
+  SQELF();
   virtual ~SQELF();
+
+  SQELF &setMetadata(const Metadata &M);
+  Metadata getMetadata() const;
 
   friend llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const SQELF &BF);
 
 private:
   sqlite3 *DB;
-  Metadata M;
 };
 } // namespace BinaryFormat
 } // namespace llvm

--- a/llvm/include/llvm/BinaryFormat/SQELF.h
+++ b/llvm/include/llvm/BinaryFormat/SQELF.h
@@ -19,7 +19,17 @@ public:
   SQELF();
   virtual ~SQELF();
 
+  /// Sets the Metadata row in the appropriate table
+  ///
+  /// Will create a Database insert statement
+  ///
+  /// \param M the metadata to insert
+  /// \returns itself for fluent use
   SQELF &setMetadata(const Metadata &M);
+
+  /// Retrieves the Metadata row in the appropriate table
+  ///
+  /// Will create a Database select statement
   Metadata getMetadata() const;
 
   friend llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const SQELF &BF);

--- a/llvm/include/llvm/BinaryFormat/SQELF.h
+++ b/llvm/include/llvm/BinaryFormat/SQELF.h
@@ -9,13 +9,21 @@ namespace BinaryFormat {
 class SQELF {
 
 public:
-  SQELF();
+  typedef struct Metadata {
+    std::string Type;
+    std::string Arch;
+    unsigned int Version;
+  } Metadata;
+
+public:
+  SQELF(const Metadata &M);
   virtual ~SQELF();
 
   friend llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const SQELF &BF);
 
 private:
-  sqlite3 *db;
+  sqlite3 *DB;
+  Metadata M;
 };
 } // namespace BinaryFormat
 } // namespace llvm

--- a/llvm/include/llvm/MC/MCSQELFObjectWriter.h
+++ b/llvm/include/llvm/MC/MCSQELFObjectWriter.h
@@ -10,7 +10,9 @@ namespace llvm {
 class MCSQELFObjectTargetWriter : public MCObjectTargetWriter {
 
 public:
-  explicit MCSQELFObjectTargetWriter();
+  explicit MCSQELFObjectTargetWriter(bool Is64Bit_, uint8_t OSABI_,
+                                     uint16_t EMachine_,
+                                     uint8_t ABIVersion_ = 0);
   virtual ~MCSQELFObjectTargetWriter();
 
   Triple::ObjectFormatType getFormat() const override { return Triple::SQELF; }
@@ -18,6 +20,21 @@ public:
   static bool classof(const MCObjectTargetWriter *W) {
     return W->getFormat() == Triple::SQELF;
   }
+
+  /// \name Accessors
+  /// @{
+  uint8_t getOSABI() const { return OSABI; }
+  uint8_t getABIVersion() const { return ABIVersion; }
+  uint16_t getEMachine() const { return EMachine; }
+  bool is64Bit() const { return Is64Bit; }
+  /// @}
+private:
+  // TODO(fzakaria): for now we are copying very similar the fields
+  // of MCELFObjectTargetWriter but they might be different later
+  const uint8_t OSABI;
+  const uint8_t ABIVersion;
+  const uint16_t EMachine;
+  const unsigned Is64Bit : 1;
 };
 
 /// Construct a new SQELF writer instance.

--- a/llvm/lib/BinaryFormat/sql/create_metadata.sql
+++ b/llvm/lib/BinaryFormat/sql/create_metadata.sql
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS Metadata
     e_machine
     TEXT, -- Architecture (EM_386, EM_X86_64, etc.)
     e_version
-    INTEGER, -- Object file version
+    INTEGER -- Object file version
     -- Only relevant in a binary file
     -- e_entry   INTEGER, -- Entry point virtual address
     -- Only relevant in a binary file

--- a/llvm/lib/BinaryFormat/sql/create_metadata.sql
+++ b/llvm/lib/BinaryFormat/sql/create_metadata.sql
@@ -23,9 +23,9 @@ CREATE TABLE IF NOT EXISTS Metadata
     PRIMARY
     KEY,
     e_type
-    INTEGER, -- Object file type (ET_REL, ET_EXEC, etc.)
+    TEXT, -- Object file type (ET_REL, ET_EXEC, etc.)
     e_machine
-    INTEGER, -- Architecture (EM_386, EM_X86_64, etc.)
+    TEXT, -- Architecture (EM_386, EM_X86_64, etc.)
     e_version
     INTEGER, -- Object file version
     -- Only relevant in a binary file
@@ -34,9 +34,9 @@ CREATE TABLE IF NOT EXISTS Metadata
     -- e_phoff      INTEGER, -- Program header table file offset
     -- Only relevant in a binary file
     --  e_shoff    INTEGER, -- Section header table file offset
-    e_flags
-    INTEGER  -- Processor-specific flags
-    -- Only relevant in a binary file
+    -- No flags defined so just omit it for now
+    --  e_flags
+    -- INTEGER  -- Processor-specific flags
     -- Only relevant in a binary file
     -- e_phentsize INTEGER, -- Program header table entry size
     -- e_phnum     INTEGER, -- Program header table entry count

--- a/llvm/lib/MC/MCSQELFObjectTargetWriter.cpp
+++ b/llvm/lib/MC/MCSQELFObjectTargetWriter.cpp
@@ -11,6 +11,11 @@
 
 using namespace llvm;
 
-MCSQELFObjectTargetWriter::MCSQELFObjectTargetWriter() {}
+MCSQELFObjectTargetWriter::MCSQELFObjectTargetWriter(bool Is64Bit_,
+                                                     uint8_t OSABI_,
+                                                     uint16_t EMachine_,
+                                                     uint8_t ABIVersion_)
+    : OSABI(OSABI_), ABIVersion(ABIVersion_), EMachine(EMachine_),
+      Is64Bit(Is64Bit_) {}
 
 MCSQELFObjectTargetWriter::~MCSQELFObjectTargetWriter() = default;

--- a/llvm/lib/MC/SQELFObjectWriter.cpp
+++ b/llvm/lib/MC/SQELFObjectWriter.cpp
@@ -58,8 +58,10 @@ SQELFObjectWriter::createMetadata(MCAssembler &Asm) {
 uint64_t SQELFObjectWriter::writeObject(MCAssembler &Asm,
                                         const MCAsmLayout &Layout) {
   BinaryFormat::SQELF::Metadata M = createMetadata(Asm);
-  BinaryFormat::SQELF sqlelf{M};
-  OS << sqlelf;
+  BinaryFormat::SQELF OF{};
+  OF.setMetadata(M);
+
+  OS << OF;
   return 0;
 }
 

--- a/llvm/lib/MC/SQELFObjectWriter.cpp
+++ b/llvm/lib/MC/SQELFObjectWriter.cpp
@@ -4,16 +4,24 @@
 // This file implements SQELF object file writer information.
 //
 //===----------------------------------------------------------------------===//
+#include "llvm/BinaryFormat/ELF.h"
 #include "llvm/BinaryFormat/SQELF.h"
+#include "llvm/MC/MCAssembler.h"
+#include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCSQELFObjectWriter.h"
 #include "llvm/MC/MCValue.h"
+// TODO(fzkaria): Consider removing -- for now we are copying some constants
+#include "llvm/BinaryFormat/ELF.h"
 
 using namespace llvm;
 
 class SQELFObjectWriter : public MCObjectWriter {
+private:
   raw_pwrite_stream &OS;
   /// The target specific ELF writer instance.
   std::unique_ptr<MCSQELFObjectTargetWriter> TargetObjectWriter;
+
+  BinaryFormat::SQELF::Metadata createMetadata(MCAssembler &Asm);
 
 public:
   SQELFObjectWriter(std::unique_ptr<MCSQELFObjectTargetWriter> MOTW,
@@ -39,9 +47,18 @@ void SQELFObjectWriter::recordRelocation(MCAssembler &Asm,
                                          const MCFixup &Fixup, MCValue Target,
                                          uint64_t &FixedValue) {}
 
+BinaryFormat::SQELF::Metadata
+SQELFObjectWriter::createMetadata(MCAssembler &Asm) {
+  const std::string Arch = std::string(
+      ELF::convertEMachineToArchName(TargetObjectWriter->getEMachine()));
+
+  return BinaryFormat::SQELF::Metadata{"Relocatable", Arch, ELF::EV_CURRENT};
+}
+
 uint64_t SQELFObjectWriter::writeObject(MCAssembler &Asm,
                                         const MCAsmLayout &Layout) {
-  BinaryFormat::SQELF sqlelf{};
+  BinaryFormat::SQELF::Metadata M = createMetadata(Asm);
+  BinaryFormat::SQELF sqlelf{M};
   OS << sqlelf;
   return 0;
 }

--- a/llvm/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp
@@ -1113,7 +1113,8 @@ public:
     // ObjectWriter? We need to first create the ObjectTargetWriter
     // which creates the ObjectWriter in AsmBackend::createObjectWriter
     if (getSTI().getTargetTriple().isOSBinFormatSQELF()) {
-      return std::make_unique<MCSQELFObjectTargetWriter>();
+      return std::make_unique<MCSQELFObjectTargetWriter>(/*IsELF64*/ true,
+                                                         OSABI, ELF::EM_X86_64);
     }
     return createX86ELFObjectWriter(/*IsELF64*/ true, OSABI, ELF::EM_X86_64);
   }


### PR DESCRIPTION
Set up scaffolding to insert the Metadata table and row in the ObjectFormat.

This sets up a few patterns:
* the SQELF class only needs a DB and stores nothing else
* get/set methods access the DB
* how to store large SQL strings using #include directive